### PR TITLE
remove username and password validations from keys endpoints

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-# web: python manage.py migrate && python manage.py generate_pids && python manage.py runserver 0.0.0.0:8080
-web: python manage.py migrate && python manage.py generate_pids && daphne label_x.asgi:application --port 8080 --bind 0.0.0.0 -v2
+web: python manage.py migrate && python manage.py generate_pids && python manage.py runserver 0.0.0.0:8080
+# web: python manage.py migrate && python manage.py generate_pids && daphne label_x.asgi:application --port 8080 --bind 0.0.0.0 -v2
 # web: python manage.py migrate && gunicorn -b 0.0.0.0:8080 label_x.wsgi:application
 worker: celery -A label_x worker --loglevel=info --concurrency=1

--- a/api_auth/serializers.py
+++ b/api_auth/serializers.py
@@ -11,20 +11,4 @@ class APIKeySerializer(serializers.ModelSerializer):
 
 
 class ApiKeyActionSerializer(serializers.Serializer):
-    """Serializer for user login"""
-
-    username = serializers.CharField()
-    password = serializers.CharField(write_only=True)
     key_id = serializers.CharField()
-
-    def validate(self, data):
-        user = authenticate(username=data["username"], password=data["password"])
-        print(user)
-        if not user:
-            raise serializers.ValidationError("Invalid credentials")
-        if not user.is_active:
-            raise serializers.ValidationError("User is not active")
-        return {
-            "user": user,
-            "key_id": data['key_id']
-        }

--- a/api_auth/urls.py
+++ b/api_auth/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
     path("generate/<str:key_type>/", GenerateApiKeyView.as_view(), name="generate-api-key"),
     path("", ViewApiKeyView.as_view(), name="view-api-key"),
     path("roll/", RollApiKey.as_view(), name="roll-api-key"),
-    path("delete/", DeleteApiKey.as_view(), name="delete-api-key"),
+    path("delete/<str:key_id>/", DeleteApiKey.as_view(), name="delete-api-key"),
 ]


### PR DESCRIPTION
In this pr, I have removed the added layer of security where a user has to provide their username and password before interacting with any of the endpoints that generates, deletes, rolls or generates api keys