### PR TITLE
Default Plan Update

### DIFF
--- a/account/apis.py
+++ b/account/apis.py
@@ -19,7 +19,7 @@ from subscription.serializers import UserDataPointsSerializer
 from task.models import Task
 from task.serializers import ProjectUpdateSerializer, TaskSerializer
 
-from .utils import IsAdminUser, IsSuperAdmin
+from .utils import IsAdminUser, IsSuperAdmin, assign_default_plan
 from .serializers import (
     Disable2faSerializer,
     LoginSerializer,
@@ -481,7 +481,10 @@ class RegisterView(APIView):
         serializer = RegisterSerializer(data=request.data)
 
         if serializer.is_valid():
-            user = serializer.save()
+            user, role = serializer.save()
+            if role == "organization":
+                assign_default_plan(user)
+                logger.info(f"Organization '{user.username}' has been assign the default free plan {datetime.now()}")
             logger.info(f"New user '{user.username}' registered successfully at {datetime.now()}")
             return Response(
                 {"status": "success", "user_data": RegisterSerializer(user).data},

--- a/account/apis.py
+++ b/account/apis.py
@@ -161,7 +161,7 @@ class GetProjectChart(generics.GenericAPIView):
         ).order_by('date')
         
         pie_chart_data= queryset.aggregate(
-            completed = Count('id', filter= ~Q(final_label__isnull=False)),
+            completed = Count('id', filter=Q(final_label__isnull=False)),
             pending = Count('id', filter=Q(processing_status='PENDING')),
             in_progress = Count('id', filter=Q(processing_status='PROCESSING')),
         )

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -60,9 +60,10 @@ class ProjectDetailSerializer(serializers.ModelSerializer):
         total_tasks = tasks.count()
         completion_percentage = (completed_tasks / total_tasks * 100) if total_tasks > 0 else 0
 
+        print(total_data_points)
         return {
             "completion_percentage": round(completion_percentage, 2),
-            "total_used_data_points": total_data_points.get('data_points', 0)
+            "total_used_data_points": total_data_points.get('data_points', 0) or 0
         }
         
         

--- a/account/serializers.py
+++ b/account/serializers.py
@@ -167,18 +167,23 @@ class RegisterSerializer(serializers.ModelSerializer):
         write_only=True,
         min_length=8,
     )
+    role = serializers.CharField(
+        write_only=True,
+        min_length=8,
+    )
 
     class Meta:
         model = CustomUser
-        fields = ["id", "username", "email", "password"]
+        fields = ["id", "username", "email", "password", "role"]
         extra_kwargs = {
             "username": {"error_messages": {"unique": "Username already exists"}},
             "email": {"error_messages": {"unique": "Email already exists"}},
         }
 
     def create(self, validated_data):
-        # Pop the password from validated_data
+        # Pop the password and role from validated_data
         password = validated_data.pop("password")
+        role = validated_data.pop("role")
 
         # Create user instance
         user = CustomUser.objects.create(**validated_data)
@@ -187,7 +192,7 @@ class RegisterSerializer(serializers.ModelSerializer):
         user.set_password(password)
         user.save()
 
-        return user
+        return user, role
 
     def validate_email(self, value):
         if CustomUser.objects.filter(email=value).exists():

--- a/account/tests.py
+++ b/account/tests.py
@@ -14,9 +14,18 @@ class RegisterTestCase(APITransactionTestCase):
         self.login_path = reverse('account:login')
         CustomUser.objects.create_user(username='dama', email="test@gmail.com")
 
-    def test_register_success(self):
+    def test_register_individual_success(self):
         response = self.client.post(
-            self.register_path, data={'username': 'dama1', "email": "test1@gmail.com", 'password': '123456789ASas@'}
+            self.register_path, data={'username': 'dama1', "email": "test1@gmail.com", 
+            'password': '123456789ASas@', 'role': "individual"}
+        )
+        for field in {"status", "user_data"}:
+            self.assertTrue(field in response.data)
+    
+    def test_register_organization_success(self):
+        response = self.client.post(
+            self.register_path, data={'username': 'dama2', "email": "test2@gmail.com", 
+            'password': '123456789ASas@', 'role': "organization"}
         )
         for field in {"status", "user_data"}:
             self.assertTrue(field in response.data)

--- a/subscription/models.py
+++ b/subscription/models.py
@@ -5,6 +5,7 @@ from django.db.models import F
 
 class SubscriptionPlan(models.Model):
     PLAN_CHOICES = (
+        ("free", "Free"),
         ("starter", "Starter"),
         ("pro", "Pro"),
         ("enterprise", "Enterprise"),

--- a/task/apis.py
+++ b/task/apis.py
@@ -594,7 +594,7 @@ class TaskCompletionStatsView(APIView):
                     "total_tasks": total_tasks,
                     "completed_tasks": completed_tasks,
                     "completion_percentage": round(completion_percentage, 2),
-                    "pending_projects": user_projects.filter(Q(status=ProjectStatusChoices.PENDING) | Q(status=ProjectStatusChoices.COMPLETED)).count()
+                    "pending_projects": user_projects.filter(Q(status=ProjectStatusChoices.PENDING) | Q(status=ProjectStatusChoices.IN_PROGRESS)).count()
                     
                 }
             }, status=status.HTTP_200_OK)


### PR DESCRIPTION
Updated registration to auto assign free(default plan) to any user registering as an organization with a plan validity of one week and 50 free data point + 50 free api request. Doesn't apply to individual user(insiders)