### PR TITLE
feat(task): Add endpoint to request +10 labellers per cluster; charge flat DPTSys update

### DIFF
--- a/subscription/models.py
+++ b/subscription/models.py
@@ -63,7 +63,8 @@ class UserDataPoints(models.Model):
     updated_at = models.DateTimeField(auto_now=True)
 
     def deduct_data_points(self, amount:int):
-        if self.data_points_balance > int(amount):
+        # Allow deduction when balance is equal to the required amount
+        if self.data_points_balance >= int(amount):
             self.data_points_balance = F("data_points_balance") - amount
             
             self.used_data_points = F('used_data_points') + amount

--- a/task/apis.py
+++ b/task/apis.py
@@ -298,7 +298,7 @@ class RequestAdditionalLabellersView(generics.GenericAPIView):
             # Check user's DPT balance
             user_data_points, created = UserDataPoints.objects.get_or_create(user=request.user)
             
-            if user_data_points.data_points_balance < total_dpt_cost:
+            if user_data_points.data_points_balance < dpt_cost_per_labeller:
                 return ErrorResponse(
                     message=f"Insufficient DPT balance. Required: {dpt_cost_per_labeller}, Available: {user_data_points.data_points_balance}",
                     status=status.HTTP_402_PAYMENT_REQUIRED
@@ -1277,7 +1277,7 @@ class TaskAnnotationView(generics.GenericAPIView):
         task_id = serializer.validated_data.get('task_id')
         labels = serializer.validated_data.get('labels', [])
         notes = serializer.validated_data.get('notes', None)  
-              
+        
         try:
             # Validate required fields
             if not task_id:
@@ -1328,6 +1328,19 @@ class TaskAnnotationView(generics.GenericAPIView):
                     'detail': f'Task is not available for labeling, current status: {task.processing_status}'
                 }, status=status.HTTP_400_BAD_REQUEST)
             
+            # Before proceeding, ensure the cluster owner has enough DPT for this task_type cost
+            from common.utils import get_dp_cost_settings
+            settings = get_dp_cost_settings()
+            # task_type is something like 'TEXT', 'IMAGE' etc. Build setting key: task_text_cost
+            required_dp_key = f"task_{str(task.cluster.task_type).lower()}_cost"
+            required_dp_for_task = int(settings.get(required_dp_key, 0))
+
+            # Get cluster owner's data points
+            owner = task.cluster.project.created_by
+            owner_data_points, _ = UserDataPoints.objects.get_or_create(user=owner)
+            if owner_data_points.data_points_balance < required_dp_for_task:
+                return ErrorResponse(message="Cluster owner does not have enough data points to satisfy this labeling request", status=status.HTTP_402_PAYMENT_REQUIRED)
+
             is_text_input_type = task.cluster.input_type  in [TaskInputTypeChoices.TEXT, TaskInputTypeChoices.MULTIPLE_CHOICE]
 
             if not is_text_input_type:
@@ -1377,6 +1390,10 @@ class TaskAnnotationView(generics.GenericAPIView):
             
             user_review_session_complete= set(task_ids) == set(user_labelled_tasks_ids)
             
+            # Deduct the DPT from the cluster owner's balance AFTER successful labeling of this task
+            if required_dp_for_task > 0:
+                owner_data_points.deduct_data_points(required_dp_for_task)
+
             if user_review_session_complete:
                 review_session.status = ManualReviewSessionStatusChoices.COMPLETED
                 review_session.save()

--- a/task/apis.py
+++ b/task/apis.py
@@ -304,8 +304,9 @@ class RequestAdditionalLabellersView(generics.GenericAPIView):
                     status=status.HTTP_402_PAYMENT_REQUIRED
                 )
             
-            # Deduct DPT from user's balance
+            # Deduct DPT from user's balance and refresh to avoid returning CombinedExpression
             user_data_points.deduct_data_points(dpt_cost_per_labeller)
+            user_data_points.refresh_from_db()
             
             # Update cluster's labeller_per_item_count
             cluster.labeller_per_item_count += additional_labellers_count
@@ -322,7 +323,7 @@ class RequestAdditionalLabellersView(generics.GenericAPIView):
                     "cluster_id": cluster_id,
                     "requested_labellers": additional_labellers_count,
                     "dpt_charged": dpt_cost_per_labeller,
-                    "remaining_dpt_balance": user_data_points.data_points_balance
+                    "remaining_dpt_balance": int(user_data_points.data_points_balance)
                 }
             )
             

--- a/task/serializers.py
+++ b/task/serializers.py
@@ -54,7 +54,7 @@ class RequestAdditionalLabellersSerializer(serializers.Serializer):
         """
         Validate that the requested number of labellers doesn't exceed reasonable limits.
         """
-        if value != 0:
+        if value != 10:
             raise serializers.ValidationError("Number of additional labellers must be 10")
         return value
 

--- a/task/serializers.py
+++ b/task/serializers.py
@@ -31,6 +31,33 @@ class GetAndValidateReviewersSerializer(serializers.Serializer):
                 raise serializers.ValidationError(f"Reviewer {reviewer_id} not found")
         return value
 
+class RequestAdditionalLabellersSerializer(serializers.Serializer):
+    """
+    Serializer for requesting additional labellers to be added to a cluster.
+    """
+    cluster_id = serializers.IntegerField()
+    additional_labellers_count = serializers.IntegerField(min_value=1, max_value=50)
+    
+    def validate_cluster_id(self, value):
+        """
+        Validate that the cluster exists and belongs to the requesting user.
+        """
+        try:
+            cluster = TaskCluster.objects.get(id=value)
+            if cluster.project.created_by != self.context['request'].user:
+                raise serializers.ValidationError("You don't have permission to modify this cluster")
+            return value
+        except TaskCluster.DoesNotExist:
+            raise serializers.ValidationError("Cluster not found")
+    
+    def validate_additional_labellers_count(self, value):
+        """
+        Validate that the requested number of labellers doesn't exceed reasonable limits.
+        """
+        if value != 0:
+            raise serializers.ValidationError("Number of additional labellers must be 10")
+        return value
+
 class AcceptClusterIdSerializer(serializers.Serializer):
     """
     Serializer for accepting a cluster ID from request data.

--- a/task/tests.py
+++ b/task/tests.py
@@ -419,7 +419,7 @@ class RequestAdditionalLabellersTestCase(APITestCase):
         """Test successful request for additional labellers"""
         data = {
             'cluster_id': self.cluster.id,
-            'additional_labellers_count': 3
+            'additional_labellers_count': 10
         }
         
         response = self.client.post(self.request_labellers_url, data)
@@ -448,19 +448,19 @@ class RequestAdditionalLabellersTestCase(APITestCase):
         response = self.client.post(self.request_labellers_url, data)
         
         self.assertEqual(response.status_code, status.HTTP_402_PAYMENT_REQUIRED)
-        self.assertIn('Insufficient DPT balance', response.data['message'])
+        self.assertIn('Insufficient DPT balance', response.data['error'])
         
     def test_request_additional_labellers_invalid_cluster(self):
         """Test request with non-existent cluster"""
         data = {
             'cluster_id': 99999,
-            'additional_labellers_count': 3
+            'additional_labellers_count': 10
         }
         
         response = self.client.post(self.request_labellers_url, data)
         
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('Cluster not found', response.data['message'])
+        self.assertIn('Cluster not found', response.data['error'])
         
     def test_request_additional_labellers_unauthorized(self):
         """Test request for cluster not owned by user"""
@@ -477,13 +477,13 @@ class RequestAdditionalLabellersTestCase(APITestCase):
         
         data = {
             'cluster_id': other_cluster.id,
-            'additional_labellers_count': 3
+            'additional_labellers_count': 10
         }
         
         response = self.client.post(self.request_labellers_url, data)
         
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("don't have permission", response.data['message'])
+        self.assertIn("don't have permission", response.data['error'])
         
     def test_request_additional_labellers_invalid_count(self):
         """Test request with invalid labeller count"""
@@ -496,7 +496,6 @@ class RequestAdditionalLabellersTestCase(APITestCase):
         
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         
-
         
     def tearDown(self):
         TaskCluster.objects.all().delete()

--- a/task/urls.py
+++ b/task/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     path('cluster/<int:cluster_id>/assign-reviewers/', apis.AssignReviewersToCluster.as_view(), name='assign-reviewers-to-cluster'),
     path('cluster/<int:cluster_id>/remove-reviewers/', apis.RemoveReviewersFromCluster.as_view(), name='remove-reviewers-from-cluster'),
     path('cluster/<int:cluster_id>/export-to-csv/', apis.ExportClusterToCsvView.as_view(), name='export-cluster-to-csv'),
+    path('cluster/request-additional-labellers/', apis.RequestAdditionalLabellersView.as_view(), name='request-additional-labellers'),
 
     # path('list/', apis.TaskListView.as_view(), name='list-tasks')
 ]


### PR DESCRIPTION
Below is a break down up updates made
- Added RequestAdditionalLabellersView to let clients request more labellers for a cluster.
- Enforced business rule: requests must be for exactly 10 additional labellers per call.
- Charged a flat DPT fee per request using system setting dp_cost_per_labeller (default 10), with balance check and deduction from UserDataPoints.
- Incremented TaskCluster.labeller_per_item_count by 10 on success and triggered assign_reviewers_to_cluster.